### PR TITLE
Expiration date being formatted after onChange callback is being called

### DIFF
--- a/src/usePaymentInputs.js
+++ b/src/usePaymentInputs.js
@@ -175,10 +175,10 @@ export default function usePaymentCard({ errorMessages, onBlur, onChange, onErro
       return e => {
         setInputTouched('expiryDate', false);
 
+        expiryDateField.current.value = utils.formatter.formatExpiry(e);
+
         props.onChange && props.onChange(e);
         onChange && onChange(e);
-
-        expiryDateField.current.value = utils.formatter.formatExpiry(e);
 
         const expiryDateError = utils.validator.getExpiryDateError(expiryDateField.current.value, { errorMessages });
         if (!expiryDateError) {


### PR DESCRIPTION
### Problem description

In current implementation `onChange` callback is being called before the expiration date field value is being formatted.

That means that consumer will rely on a wrong state of the field while trying to read the value.

### Proposed solution

Update field with formatted value before firing the `onChange` callback.