### PR TITLE
fix: Fix input cursor jumping to wrong position on ELO type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-payment-inputs",
-  "version": "1.1.4",
+  "version": "1.1.4-patch.0",
   "description": "A zero-dependency React Hook & Container to help with payment card input fields.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/usePaymentInputs.js
+++ b/src/usePaymentInputs.js
@@ -107,9 +107,7 @@ export default function usePaymentCard({
         // the input field. Here, we want to reposition the cursor to the correct place.
         requestAnimationFrame(() => {
           if (document.activeElement !== cardNumberField.current) return;
-          if (cardNumberField.current.value[cursorPosition - 1] === ' ') {
-            cursorPosition = cursorPosition + 1;
-          }
+          cursorPosition = cursorPosition + 1;
           cardNumberField.current.setSelectionRange(cursorPosition, cursorPosition);
         });
 


### PR DESCRIPTION
Fixed the cursor position when the input mask are applied to ELO type.

Tested with `6362970000457013` and `6362971747129170` card numbers

Signed-off-by: Raí Siqueira <rai93siqueira@gmail.com>