### PR TITLE
Pass event through onFocus

### DIFF
--- a/src/usePaymentInputs.js
+++ b/src/usePaymentInputs.js
@@ -126,7 +126,7 @@ export default function usePaymentCard({
 
   const handleFocusCardNumber = React.useCallback((props = {}) => {
     return e => {
-      props.onFocus && props.onFocus();
+      props.onFocus && props.onFocus(e);
       setFocused('cardNumber');
     };
   }, []);


### PR DESCRIPTION
On Focus should pass through the event. Pretty sure this is an appropriate fix.
```js
  const handleFocusCardNumber = React.useCallback((props = {}) => {
    return e => {
      props.onFocus && props.onFocus(e); //should pass through original event
      setFocused('cardNumber');
    };
  }, []);
```