### PR TITLE
fixed deprecated keyCode to supported e.key

### DIFF
--- a/src/usePaymentInputs.js
+++ b/src/usePaymentInputs.js
@@ -138,7 +138,7 @@ export default function usePaymentCard({
 
       props.onKeyPress && props.onKeyPress(e);
 
-      if (e.keyCode !== utils.ENTER_KEY_CODE) {
+      if (e.key !== utils.ENTER_KEY_CODE) {
         if (!utils.validator.isNumeric(e)) {
           e.preventDefault();
         }
@@ -215,7 +215,7 @@ export default function usePaymentCard({
       return e => {
         props.onKeyDown && props.onKeyDown(e);
 
-        if (e.keyCode === utils.BACKSPACE_KEY_CODE && !e.target.value && autoFocus) {
+        if (e.key === utils.BACKSPACE_KEY_CODE && !e.target.value && autoFocus) {
           cardNumberField.current && cardNumberField.current.focus();
         }
       };
@@ -230,7 +230,7 @@ export default function usePaymentCard({
 
       props.onKeyPress && props.onKeyPress(e);
 
-      if (e.keyCode !== utils.ENTER_KEY_CODE) {
+      if (e.key !== utils.ENTER_KEY_CODE) {
         if (!utils.validator.isNumeric(e)) {
           e.preventDefault();
         }
@@ -313,7 +313,7 @@ export default function usePaymentCard({
       return e => {
         props.onKeyDown && props.onKeyDown(e);
 
-        if (e.keyCode === utils.BACKSPACE_KEY_CODE && !e.target.value && autoFocus) {
+        if (e.key === utils.BACKSPACE_KEY_CODE && !e.target.value && autoFocus) {
           expiryDateField.current && expiryDateField.current.focus();
         }
       };
@@ -328,7 +328,7 @@ export default function usePaymentCard({
 
       props.onKeyPress && props.onKeyPress(e);
 
-      if (e.keyCode !== utils.ENTER_KEY_CODE) {
+      if (e.key !== utils.ENTER_KEY_CODE) {
         if (!utils.validator.isNumeric(e)) {
           e.preventDefault();
         }
@@ -405,7 +405,7 @@ export default function usePaymentCard({
       return e => {
         props.onKeyDown && props.onKeyDown(e);
 
-        if (e.keyCode === utils.BACKSPACE_KEY_CODE && !e.target.value && autoFocus) {
+        if (e.key === utils.BACKSPACE_KEY_CODE && !e.target.value && autoFocus) {
           cvcField.current && cvcField.current.focus();
         }
       };
@@ -417,7 +417,7 @@ export default function usePaymentCard({
     return e => {
       props.onKeyPress && props.onKeyPress(e);
 
-      if (e.keyCode !== utils.ENTER_KEY_CODE) {
+      if (e.key !== utils.ENTER_KEY_CODE) {
         if (!utils.validator.isNumeric(e)) {
           e.preventDefault();
         }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,8 +2,8 @@ import * as cardTypes from './cardTypes';
 import * as formatter from './formatter';
 import * as validator from './validator';
 
-export const BACKSPACE_KEY_CODE = 8;
-export const ENTER_KEY_CODE = 0;
+export const BACKSPACE_KEY_CODE = 'Backspace';
+export const ENTER_KEY_CODE = 'Enter';
 
 export const isHighlighted = () => (window.getSelection() || { type: undefined }).type === 'Range';
 


### PR DESCRIPTION
Use of event.keyCode returned 0 on all keys, non-numeric and numeric, and backspace returned 8. This caused code to be unreachable in several blocks. For example in `handleKeyPressCVC` the following code:
```js
if (e.keyCode !== utils.ENTER_KEY_CODE) {
        if (!utils.validator.isNumeric(e)) {
          e.preventDefault();
        }
        if (cardType && cvc.length >= cardType.code.length) {
          e.preventDefault();
        }
        if (cvc.length >= 4) {
          e.preventDefault();
        }
    }
```
was only reachable when e.keyCode did not equal 0 (i.e on a backspace).

I fixed this by switching to using the supported `key` (as `keyCode` has been deprecated and had issues in Firefox)
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

This has fixed a variety of issues such as the ones mentioned by me in #39 , and others in #37 #20 