### PR TITLE
Enhancement: Options to set Initial Values, Show Errors onBlur, and added functions to touch/reset form.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-prettier": "3.0.1",
     "fannypack": "4.19.22",
     "final-form": "4.13.0",
-    "formik": "1.5.7",
+    "formik": "2.1.3",
     "react": "16.8.6",
     "react-bootstrap": "1.0.0-beta.8",
     "react-dom": "16.8.6",

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -271,23 +271,31 @@ storiesOf('usePaymentInputs', module)
     function Component() {
       const {
         meta,
+        helpers,
         getCardImageProps,
         getCardNumberProps,
         getExpiryDateProps,
         getCVCProps,
+        getZIPProps,
         wrapperProps
-      } = usePaymentInputs();
+      } = usePaymentInputs({
+        touchFormOnBlur: true
+      });
 
       return (
         <Formik
           initialValues={{
             cardNumber: '',
             expiryDate: '',
-            cvc: ''
+            cvc: '',
+            zip: ''
           }}
-          onSubmit={data => console.log(data)}
+          onSubmit={data => {
+            console.log(data)
+          }}
           validate={() => {
             let errors = {};
+
             if (meta.erroredInputs.cardNumber) {
               errors.cardNumber = meta.erroredInputs.cardNumber;
             }
@@ -297,31 +305,78 @@ storiesOf('usePaymentInputs', module)
             if (meta.erroredInputs.cvc) {
               errors.cvc = meta.erroredInputs.cvc;
             }
+
             return errors;
           }}
+          onReset={(values, formikbag) => {
+            
+          }}
         >
-          {({ handleSubmit }) => (
-            <form onSubmit={handleSubmit}>
+          {(props) => (
+            <form onSubmit={props.handleSubmit}>
               <div>
                 <PaymentInputsWrapper {...wrapperProps}>
                   <svg {...getCardImageProps({ images })} />
                   <FormikField name="cardNumber">
-                    {({ field }) => (
-                      <input {...getCardNumberProps({ onBlur: field.onBlur, onChange: field.onChange })} />
+                    {({ field, form, meta }) => (
+                      <input {...getCardNumberProps({
+                          onBlur: field.onBlur,
+                          onChange: field.onChange,
+                          value: form.values.cardNumber
+                        })}
+                        
+                      />
                     )}
                   </FormikField>
                   <FormikField name="expiryDate">
-                    {({ field }) => (
-                      <input {...getExpiryDateProps({ onBlur: field.onBlur, onChange: field.onChange })} />
+                    {({ field, form, meta }) => (
+                      <input {...getExpiryDateProps({
+                          onBlur: field.onBlur,
+                          onChange: field.onChange,
+                          value: form.values.expiryDate
+                        })}
+                      />
                     )}
                   </FormikField>
                   <FormikField name="cvc">
-                    {({ field }) => <input {...getCVCProps({ onBlur: field.onBlur, onChange: field.onChange })} />}
+                    {({ field, form, meta }) => (
+                      <input {...getCVCProps({
+                          onBlur:field.onBlur,
+                          onChange: field.onChange,
+                          value: form.values.cvc
+                        })}
+                      />
+                    )}
+                  </FormikField>
+                  <FormikField name="zip">
+                    {({ field, form, meta }) => (
+                      <input {...getZIPProps({
+                          onBlur:field.onBlur,
+                          onChange: field.onChange,
+                          value: form.values.zip
+                        })}
+                      />
+                    )}
                   </FormikField>
                 </PaymentInputsWrapper>
               </div>
-              <Button marginTop="major-2" type="submit">
+              <br/>
+
+              <Button margin="major-2" type="submit" onClick={(e) => { 
+                  helpers.setInputTouched('cardNumber', true);
+                  helpers.setInputTouched('expiryDate', true);
+                  helpers.setInputTouched('cvc', true);
+
+                  props.handleSubmit(e)
+                }}
+              >
                 Submit
+              </Button>
+              <Button margin="major-2" onClick={(e) => {
+                helpers.resetForm({...props.initialValues});
+                props.handleReset(e);
+              }} type='reset'>
+                Reset
               </Button>
             </form>
           )}


### PR DESCRIPTION
This PR is a first-pass at exposing flexibility in the payment input wrapper. I wrote this primarily to work with Formik better (reset the form, touch fields on submit etc.), however the functionality works with a default form as well.

Included is the functionality to:
- specify initial values for the form to populate with
- expose a reset function that, when called, resets the form to default errors, and in an un-touched state
- provided an optional attribute that, when applied, will show form validation errors onBlur

Fixed:
  - original code looked for what field the user was navigating to. If the field was an input, it would not display the wrapper's error text. re-wrote this part to look specifically for the input fields associated with the lib. navigating to an input field not associated with the ui wrapper will properly display the errors.
 - open issues associated with this PR: #1 , #21 , #25 
 - I also changed the position of when a field / form is being set as 'touched' to be after the calculation of that field's errors. This fixed an issue of determining if a field has errored onBlur.

Updated:
 - updated formik in dev dependencies in order to ensure story works in the latest version

Known Issues:
 - I noticed this issue while working on the initial values addition: useLayoutEffect won't format a default card value as it's intended. a given card number like: '4610500040003000' is only formatted with useLayoutEffect if the other useLayoutEffects are removed. Since those don't work, the work around is to add spaces to your initial values to avoid any issues.