### PR TITLE
fix: allow writing over when text is selected

### DIFF
--- a/src/usePaymentInputs.js
+++ b/src/usePaymentInputs.js
@@ -142,7 +142,7 @@ export default function usePaymentCard({
         if (!utils.validator.isNumeric(e)) {
           e.preventDefault();
         }
-        if (utils.validator.hasCardNumberReachedMaxLength(cardNumber)) {
+        if (utils.validator.hasCardNumberReachedMaxLength(cardNumber) && e.target.selectionStart === e.target.selectionEnd) {
           e.preventDefault();
         }
       }
@@ -234,7 +234,7 @@ export default function usePaymentCard({
         if (!utils.validator.isNumeric(e)) {
           e.preventDefault();
         }
-        if (expiryDate.length >= 4) {
+        if (expiryDate.length >= 4 && e.target.selectionStart === e.target.selectionEnd) {
           e.preventDefault();
         }
       }
@@ -332,10 +332,10 @@ export default function usePaymentCard({
         if (!utils.validator.isNumeric(e)) {
           e.preventDefault();
         }
-        if (cardType && cvc.length >= cardType.code.length) {
+        if (cardType && cvc.length >= cardType.code.length && e.target.selectionStart === e.target.selectionEnd) {
           e.preventDefault();
         }
-        if (cvc.length >= 4) {
+        if (cvc.length >= 4 && e.target.selectionStart === e.target.selectionEnd) {
           e.preventDefault();
         }
       }


### PR DESCRIPTION
Hello 👋 ,

Thanks a lot for putting this library together. We've come across this issue recently that one cannot directly write over a selection of text, and instead they would have to clear the input text first with backspace. I added a fix with this PR so that it will only prevent adding more characters to the text if there is no selection. Let me know please if you think this makes sense and if we could get this fix released. Thanks!