### PR TITLE
Export validators

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export { default as usePaymentInputs } from './usePaymentInputs';
 export { default as PaymentInputsContainer } from './PaymentInputsContainer';
 export { default as PaymentInputsWrapper } from './PaymentInputsWrapper';
+export { getCardNumberError, getExpiryDateError, getCVCError, getZIPError } from './utils/validator';


### PR DESCRIPTION
There are some cases in which it's useful to use the validators already defined in this library without needing to install another library just for that. For example, when creating a custom validator with `yup`.